### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Handlers
 Handlers are decorated with ``@app.route(url_pattern)``. Routes are managed by
 the `Routes`_ library.
 
-.. _Routes: https://routes.readthedocs.org/en/latest/
+.. _Routes: https://routes.readthedocs.io/en/latest/
 
 Handlers have several way to send data back to the client:
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
